### PR TITLE
Add unit tests and GitHub Actions CI (v0.2.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -v -race -coverprofile=coverage.out
+
+      - name: Coverage summary
+        run: go tool cover -func=coverage.out
+
+  vet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Vet
+        run: go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	go install $(LDFLAGS) .
 
 test:
-	go test ./... -v
+	go test ./... -v -race
 
 lint:
 	golangci-lint run ./...

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,319 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cerrors "github.com/planitaicojp/freee-cli/internal/errors"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewClient("test-token", 12345)
+	if c.Token != "test-token" {
+		t.Errorf("Token = %q, want %q", c.Token, "test-token")
+	}
+	if c.CompanyID != 12345 {
+		t.Errorf("CompanyID = %d, want %d", c.CompanyID, 12345)
+	}
+	if c.HTTP == nil {
+		t.Error("HTTP client is nil")
+	}
+}
+
+func TestClient_Do_SetsHeaders(t *testing.T) {
+	var gotHeaders http.Header
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	c := NewClient("my-token", 1)
+	c.HTTP = ts.Client()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/test", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do error: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := gotHeaders.Get("Authorization"); got != "Bearer my-token" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer my-token")
+	}
+	if got := gotHeaders.Get("User-Agent"); got != UserAgent {
+		t.Errorf("User-Agent = %q, want %q", got, UserAgent)
+	}
+	if got := gotHeaders.Get("Accept"); got != "application/json" {
+		t.Errorf("Accept = %q, want %q", got, "application/json")
+	}
+}
+
+func TestClient_Do_NoTokenSkipsAuth(t *testing.T) {
+	var gotHeaders http.Header
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	c := NewClient("", 1)
+	c.HTTP = ts.Client()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/test", nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do error: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := gotHeaders.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be empty, got %q", got)
+	}
+}
+
+func TestClient_Get_DecodesJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		json.NewEncoder(w).Encode(map[string]string{"name": "test"})
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	var result map[string]string
+	if err := c.Get(ts.URL+"/api", &result); err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if result["name"] != "test" {
+		t.Errorf("name = %q, want %q", result["name"], "test")
+	}
+}
+
+func TestClient_Get_NilResult(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	if err := c.Get(ts.URL+"/api", nil); err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+}
+
+func TestClient_Post(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		json.NewEncoder(w).Encode(map[string]any{"id": 1, "received": body})
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	var result map[string]any
+	resp, err := c.Post(ts.URL+"/api", map[string]string{"key": "val"}, &result)
+	if err != nil {
+		t.Fatalf("Post error: %v", err)
+	}
+	resp.Body.Close()
+
+	if result["id"] != float64(1) {
+		t.Errorf("id = %v, want 1", result["id"])
+	}
+}
+
+func TestClient_Put(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	var result map[string]string
+	if err := c.Put(ts.URL+"/api", map[string]string{"a": "b"}, &result); err != nil {
+		t.Fatalf("Put error: %v", err)
+	}
+	if result["status"] != "updated" {
+		t.Errorf("status = %q, want %q", result["status"], "updated")
+	}
+}
+
+func TestClient_Delete(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	if err := c.Delete(ts.URL + "/api"); err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+}
+
+func TestClient_Do_401ReturnsAuthError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"status_code":401,"errors":[{"type":"unauthorized","messages":["invalid token"]}]}`))
+	}))
+	defer ts.Close()
+
+	c := NewClient("bad-token", 1)
+	c.HTTP = ts.Client()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api", nil)
+	_, err := c.Do(req)
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if _, ok := err.(*cerrors.AuthError); !ok {
+		t.Errorf("expected *AuthError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_Do_404ReturnsNotFoundError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api", nil)
+	_, err := c.Do(req)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if _, ok := err.(*cerrors.NotFoundError); !ok {
+		t.Errorf("expected *NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_Do_400ReturnsAPIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"status_code":400,"errors":[{"type":"invalid_param","messages":["amount is required"]}]}`))
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api", nil)
+	_, err := c.Do(req)
+	if err == nil {
+		t.Fatal("expected error for 400")
+	}
+	apiErr, ok := err.(*cerrors.APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 400 {
+		t.Errorf("StatusCode = %d, want 400", apiErr.StatusCode)
+	}
+	if apiErr.Code != "invalid_param" {
+		t.Errorf("Code = %q, want %q", apiErr.Code, "invalid_param")
+	}
+}
+
+func TestRetryAfterDuration(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryAfter string
+		attempt    int
+		wantSecs   int
+	}{
+		{"with header", "5", 0, 5},
+		{"no header fallback", "", 0, 1},
+		{"no header attempt 1", "", 1, 2},
+		{"invalid header", "abc", 0, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			if tt.retryAfter != "" {
+				resp.Header.Set("Retry-After", tt.retryAfter)
+			}
+			got := retryAfterDuration(resp, tt.attempt)
+			want := tt.wantSecs
+			if int(got.Seconds()) != want {
+				t.Errorf("got %v, want %ds", got, want)
+			}
+		})
+	}
+}
+
+func TestParseAPIError_FreeeFormat(t *testing.T) {
+	body := `{"status_code":400,"errors":[{"type":"validation","messages":["field is required","invalid format"]}]}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api", nil)
+	_, err := c.Do(req)
+
+	apiErr, ok := err.(*cerrors.APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.Code != "validation" {
+		t.Errorf("Code = %q, want %q", apiErr.Code, "validation")
+	}
+	if apiErr.Message != "[field is required invalid format]" {
+		t.Errorf("Message = %q", apiErr.Message)
+	}
+}
+
+func TestParseAPIError_NonFreeeFormat(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`Internal Server Error`))
+	}))
+	defer ts.Close()
+
+	c := NewClient("tok", 1)
+	c.HTTP = ts.Client()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api", nil)
+	_, err := c.Do(req)
+
+	apiErr, ok := err.(*cerrors.APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 500 {
+		t.Errorf("StatusCode = %d, want 500", apiErr.StatusCode)
+	}
+	if apiErr.Message != "Internal Server Error" {
+		t.Errorf("Message = %q", apiErr.Message)
+	}
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,136 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  APIError
+		want string
+	}{
+		{
+			name: "with code",
+			err:  APIError{StatusCode: 400, Code: "invalid_param", Message: "bad request"},
+			want: "API error (HTTP 400, invalid_param): bad request",
+		},
+		{
+			name: "without code",
+			err:  APIError{StatusCode: 500, Message: "internal"},
+			want: "API error (HTTP 500): internal",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIError_ExitCode(t *testing.T) {
+	err := &APIError{StatusCode: 400}
+	if got := err.ExitCode(); got != ExitAPI {
+		t.Errorf("got %d, want %d", got, ExitAPI)
+	}
+}
+
+func TestAuthError(t *testing.T) {
+	err := &AuthError{Message: "token expired"}
+	if got := err.Error(); got != "auth error: token expired\nhint: run 'freee auth login' to authenticate" {
+		t.Errorf("unexpected error message: %q", got)
+	}
+	if got := err.ExitCode(); got != ExitAuth {
+		t.Errorf("got exit code %d, want %d", got, ExitAuth)
+	}
+}
+
+func TestConfigError(t *testing.T) {
+	err := &ConfigError{Message: "no profile"}
+	if got := err.Error(); got != "config error: no profile\nhint: run 'freee auth login' to set up a profile" {
+		t.Errorf("unexpected error message: %q", got)
+	}
+	if got := err.ExitCode(); got != ExitGeneral {
+		t.Errorf("got exit code %d, want %d", got, ExitGeneral)
+	}
+}
+
+func TestNotFoundError(t *testing.T) {
+	err := &NotFoundError{Resource: "deal", ID: "123"}
+	if got := err.Error(); got != "deal not found: 123\nhint: check the ID and ensure the resource exists in the current company" {
+		t.Errorf("unexpected error message: %q", got)
+	}
+	if got := err.ExitCode(); got != ExitNotFound {
+		t.Errorf("got exit code %d, want %d", got, ExitNotFound)
+	}
+}
+
+func TestValidationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  ValidationError
+		want string
+	}{
+		{
+			name: "with field",
+			err:  ValidationError{Field: "amount", Message: "must be positive"},
+			want: "validation error on amount: must be positive",
+		},
+		{
+			name: "without field",
+			err:  ValidationError{Message: "invalid input"},
+			want: "validation error: invalid input",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+	if got := (&ValidationError{}).ExitCode(); got != ExitValidation {
+		t.Errorf("got exit code %d, want %d", got, ExitValidation)
+	}
+}
+
+func TestNetworkError(t *testing.T) {
+	inner := fmt.Errorf("connection refused")
+	err := &NetworkError{Err: inner}
+	if got := err.Error(); got != "network error: connection refused\nhint: check your internet connection and try again" {
+		t.Errorf("unexpected error message: %q", got)
+	}
+	if got := err.Unwrap(); got != inner {
+		t.Errorf("Unwrap returned %v, want %v", got, inner)
+	}
+	if got := err.ExitCode(); got != ExitNetwork {
+		t.Errorf("got exit code %d, want %d", got, ExitNetwork)
+	}
+}
+
+func TestGetExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil", nil, ExitOK},
+		{"api error", &APIError{StatusCode: 400}, ExitAPI},
+		{"auth error", &AuthError{}, ExitAuth},
+		{"not found", &NotFoundError{}, ExitNotFound},
+		{"validation", &ValidationError{}, ExitValidation},
+		{"network", &NetworkError{Err: fmt.Errorf("x")}, ExitNetwork},
+		{"config", &ConfigError{}, ExitGeneral},
+		{"generic error", fmt.Errorf("unknown"), ExitGeneral},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetExitCode(tt.err); got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,168 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type testRow struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{"json", "*output.JSONFormatter"},
+		{"yaml", "*output.YAMLFormatter"},
+		{"csv", "*output.CSVFormatter"},
+		{"table", "*output.TableFormatter"},
+		{"", "*output.TableFormatter"},
+		{"unknown", "*output.TableFormatter"},
+	}
+	for _, tt := range tests {
+		name := tt.format
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := New(tt.format)
+			if f == nil {
+				t.Fatal("New returned nil")
+			}
+			got := fmt.Sprintf("%T", f)
+			if got != tt.want {
+				t.Errorf("New(%q) = %s, want %s", tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONFormatter(t *testing.T) {
+	var buf bytes.Buffer
+	f := &JSONFormatter{}
+	data := []testRow{{ID: 1, Name: "Alice"}, {ID: 2, Name: "Bob"}}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+
+	var result []testRow
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("JSON unmarshal error: %v", err)
+	}
+	if len(result) != 2 || result[0].Name != "Alice" {
+		t.Errorf("unexpected result: %+v", result)
+	}
+}
+
+func TestJSONFormatter_SingleObject(t *testing.T) {
+	var buf bytes.Buffer
+	f := &JSONFormatter{}
+	data := map[string]string{"key": "value"}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"key"`) {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}
+
+func TestYAMLFormatter(t *testing.T) {
+	var buf bytes.Buffer
+	f := &YAMLFormatter{}
+	data := []testRow{{ID: 1, Name: "Test"}}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "id: 1") || !strings.Contains(out, "name: Test") {
+		t.Errorf("unexpected YAML output: %s", out)
+	}
+}
+
+func TestCSVFormatter(t *testing.T) {
+	var buf bytes.Buffer
+	f := &CSVFormatter{}
+	data := []testRow{{ID: 1, Name: "Alice"}, {ID: 2, Name: "Bob"}}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (header + 2 rows), got %d", len(lines))
+	}
+	if lines[0] != "id,name" {
+		t.Errorf("unexpected header: %q", lines[0])
+	}
+	if lines[1] != "1,Alice" {
+		t.Errorf("unexpected row 1: %q", lines[1])
+	}
+}
+
+func TestCSVFormatter_EmptySlice(t *testing.T) {
+	var buf bytes.Buffer
+	f := &CSVFormatter{}
+	if err := f.Format(&buf, []testRow{}); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty slice, got %q", buf.String())
+	}
+}
+
+func TestCSVFormatter_NonSlice(t *testing.T) {
+	var buf bytes.Buffer
+	f := &CSVFormatter{}
+	err := f.Format(&buf, "not a slice")
+	if err == nil {
+		t.Fatal("expected error for non-slice input")
+	}
+}
+
+func TestTableFormatter(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TableFormatter{}
+	data := []testRow{{ID: 1, Name: "Alice"}, {ID: 2, Name: "Bob"}}
+
+	if err := f.Format(&buf, data); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "ID") || !strings.Contains(out, "NAME") {
+		t.Errorf("expected uppercase headers, got: %s", out)
+	}
+	if !strings.Contains(out, "Alice") || !strings.Contains(out, "Bob") {
+		t.Errorf("expected data rows, got: %s", out)
+	}
+}
+
+func TestTableFormatter_EmptySlice(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TableFormatter{}
+	if err := f.Format(&buf, []testRow{}); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output, got %q", buf.String())
+	}
+}
+
+func TestTableFormatter_NonSlice(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TableFormatter{}
+	if err := f.Format(&buf, "hello"); err != nil {
+		t.Fatalf("Format error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "hello") {
+		t.Errorf("expected string output, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for `internal/errors`, `internal/api` (httptest mock), and `internal/output` (JSON/YAML/CSV/Table formatters)
- Add GitHub Actions CI workflow (test with race detector + coverage, go vet)
- Add `-race` flag to `make test`

## Test plan
- [ ] Verify CI passes on GitHub Actions
- [ ] Run `make test` locally with test account

🤖 Generated with [Claude Code](https://claude.com/claude-code)