### PR TITLE
feat: v0.5.0 manual-journal design spec

### DIFF
--- a/docs/superpowers/specs/2026-03-30-v0.5.0-manual-journal-design.md
+++ b/docs/superpowers/specs/2026-03-30-v0.5.0-manual-journal-design.md
@@ -56,7 +56,7 @@ freee manual-journal show 12345
 
 - 위치 인자: manual journal ID (필수)
 - key-value 출력: ID, Date, Adjustment, TxnNumber
-- Details 섹션: 각 행의 entry_side, account_item_id, amount, vat, tax_code, description 표시
+- Details 섹션: 각 행의 entry_side, account_item_id, amount, vat, tax_code, partner_id, item_id, section_id, description 표시 (0이 아닌 필드만 출력)
 
 ### 3. create — 이중 입력 모드
 
@@ -90,7 +90,7 @@ freee manual-journal create --date 2026-03-15 --details-file entries.json
 | `--credit-account-id` | int64 | Simple mode | 대변 勘定科目 ID |
 | `--credit-account-name` | string | Simple mode | 대변 勘定科目명 (name resolve) |
 | `--amount` | int64 | Simple mode | 금액 |
-| `--tax-code` | int64 | Yes (simple mode) | 세구분 코드 (freee API 필수) |
+| `--tax-code` | int64 | Yes (simple mode) | 세구분 코드 — 단순 모드에서는 차변/대변 모두에 동일 적용 |
 | `--description` | string | No | 적요 |
 | `--adjustment` | bool | No | 결산 정리 분개 여부 |
 | `--details-json` | string | JSON mode | 명세 JSON 문자열 |
@@ -103,19 +103,21 @@ freee manual-journal create --date 2026-03-15 --details-file entries.json
 - JSON 모드: `--details-json` 또는 `--details-file` 중 하나만 지정
 - 차변 합계 = 대변 합계 검증 (client-side)
 - details 행 수 합계 100행 이하 검증 (client-side)
+- JSON 모드: 각 detail 항목에 `tax_code` 필수 (client-side 검증)
 
 ### 4. update
 
 ```bash
 freee manual-journal update 12345 --date 2026-03-20
 freee manual-journal update 12345 --details-json '[...]'
+freee manual-journal update 12345 --debit-account-id 100 --credit-account-id 200 --amount 60000 --tax-code 1
 ```
 
 - 위치 인자: manual journal ID (필수)
 - **GET-then-merge 전략**: freee PUT API는 `issue_date`와 `details`가 필수. 사용자가 일부 필드만 변경해도, 먼저 GET으로 현재 상태를 가져온 뒤 변경 필드를 머지하여 전체 body를 전송한다.
-- 단순 모드 + JSON 모드 모두 지원
+- **단순 모드 = 완전 대체**: 단순 모드 플래그 사용 시 기존 details를 새로운 1:1 분개로 완전히 대체한다. 다중 라인 분개의 부분 수정이 필요하면 `--details-json` 또는 `--details-file`을 사용해야 한다.
+- JSON 모드: `--details-json` 또는 `--details-file`로 전체 details 배열 교체
 - `--dry-run` 지원
-- 주의: details를 업데이트하면 전체 교체 (freee API 동작)
 
 ### 5. delete
 
@@ -158,7 +160,7 @@ type ManualJournalDetail struct {
     ItemID        int64  `json:"item_id"`
     SectionID     int64   `json:"section_id"`
     TagIDs        []int64 `json:"tag_ids"`
-    Description   string  `json:"description"`
+    Description   string `json:"description"`
 }
 
 type ManualJournalRow struct {


### PR DESCRIPTION
## Summary
- Phase 2 첫 번째 서브그룹: `freee manual-journal` CRUD 5개 커맨드 설계 스펙
- 이중 입력 모드 설계: 단순 플래그 (1:1 분개) + JSON 모드 (다행 분개)
- 기존 deal 패턴을 답습하되, 차변/대변 구조와 GET-then-merge update 전략 추가

## Key Design Decisions
- `--tax-code` simple mode에서 필수 (freee API 요구사항)
- update는 GET-then-merge 전략 (freee PUT API가 `issue_date` + `details` 필수)
- client-side 검증: 차대 균형 + 100행 제한
- list 필터: `--item-id`, `--section-id`, `--txn-number` 추가

## Files
- `docs/superpowers/specs/2026-03-30-v0.5.0-manual-journal-design.md`

## Review Request
설계 스펙 리뷰 요청합니다. 구현 전에 피드백 반영 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)